### PR TITLE
updated sleep duration

### DIFF
--- a/config/colosseum.json
+++ b/config/colosseum.json
@@ -2,8 +2,9 @@
   "env": "colosseum",
   "blockTime": 12000,
   "machinesRunning": 4,
-  "targetTps": 2000,
+  "targetTps": 10,
   "increment": false,
   "etxFreq": 0.1,
-  "memPoolMax": 12000
+  "memPoolMax": 12000,
+  "startingSleepDuration": 3000
 }


### PR DESCRIPTION
Making note on this PR. We need to avoid sleeping on `transactor.makeUTXOTransaction([]types.TxIn{in}, outs, privKeys, pubKeys)` since the `txMutex` lock is held. When the `txMutex` lock is held we cannot listen to new blocks and update the `spendableOuts` set.